### PR TITLE
added disabled styling to Ghost and Primary buttons (fixes #62)

### DIFF
--- a/components/button/Ghost.tsx
+++ b/components/button/Ghost.tsx
@@ -6,19 +6,32 @@ type GhostProps = {
   children?: ReactNode | string | null
 } & ButtonTypes
 
-const Ghost = ({ children, ...props }: GhostProps) => (
-  <button {...props}>
-    <style jsx>{`
-      button {
-        border: none;
-        cursor: pointer;
-        background: transparent;
-        width: fit-content;
-        height: fit-content;
-      }
-    `}</style>
-    {children}
-  </button>
-)
+const Ghost = ({ children, ...props }: GhostProps) => {
+  return (
+    <button {...props} disabled={props?.disabled || false}>
+      <style jsx>{`
+        button {
+          border: none;
+          cursor: pointer;
+          background: transparent;
+          width: fit-content;
+          height: fit-content;
+        }
+
+        button:disabled {
+          border: none;
+          cursor: not-allowed;
+          background: transparent;
+          width: fit-content;
+          height: fit-content;
+        }
+        button:disabled:hover {
+          opacity: 0.5;
+        }
+      `}</style>
+      {children}
+    </button>
+  )
+}
 
 export default Ghost

--- a/components/button/Primary.tsx
+++ b/components/button/Primary.tsx
@@ -6,23 +6,32 @@ type PrimaryProps = {
   children?: ReactNode | string | null
 } & ButtonTypes
 
-const Primary = ({ children, ...props }: PrimaryProps) => (
-  <button {...props}>
-    <style jsx>{`
-      button {
-        border: none;
-        cursor: pointer;
-        background: var(--primary);
-        color: var(--white);
-        width: 100%;
-        height: 4rem;
-        display: block;
-        margin: 0 auto;
-        font-weight: var(--font-bold);
-      }
-    `}</style>
-    {children}
-  </button>
-)
+const Primary = ({ children, ...props }: PrimaryProps) => {
+  return (
+    <button {...props} disabled={props?.disabled || false}>
+      <style jsx>{`
+        button {
+          border: none;
+          cursor: pointer;
+          background: var(--primary);
+          color: var(--white);
+          width: 100%;
+          height: 4rem;
+          display: block;
+          margin: 0 auto;
+          font-weight: var(--font-bold);
+        }
+
+        button:disabled {
+          cursor: not-allowed;
+        }
+        button:disabled:hover {
+          opacity: 0.5;
+        }
+      `}</style>
+      {children}
+    </button>
+  )
+}
 
 export default Primary


### PR DESCRIPTION
Changes made to `Ghost` :
When passed the disabled prop, hovering over the button:
-  shows `not-allowed` cursor
-  changes the opacity of the button to `.5`
-  blocks clicks

Video demo of change:

https://user-images.githubusercontent.com/43625213/156953421-fac44d09-b1df-4e8b-b400-3866bbd6dab4.mov

Changes made to `Primary` :
When passed the disabled prop, hovering over the button:
-  shows `not-allowed` cursor
-  changes the opacity of the button to `.5`
-  blocks clicks

Video demo of change:

https://user-images.githubusercontent.com/43625213/156953443-ee0f98b2-7ff7-47c0-9366-f2eda8703b35.mov